### PR TITLE
Minor update for openbabel import and safe directory render

### DIFF
--- a/easy_rmg_model/species/converter.py
+++ b/easy_rmg_model/species/converter.py
@@ -4,7 +4,7 @@
 
 import os
 
-import pybel
+from openbabel import pybel
 
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.molecule.converter import from_ob_mol

--- a/easy_rmg_model/template_writer/input/arkane_input.py
+++ b/easy_rmg_model/template_writer/input/arkane_input.py
@@ -52,12 +52,12 @@ externalSymmetry = {{ external_symmetry }}
 opticalIsomers = {{ optical_isomers }}
 
 energy = {
-    '{{ model_chemistry }}': Log('{{ energy }}'),
+    '{{ model_chemistry }}': Log('{{ energy | safe }}'),
 }
 
-geometry = Log('{{ freq }}')
+geometry = Log('{{ freq | safe }}')
 
-frequencies = Log('{{ freq }}')
+frequencies = Log('{{ freq | safe }}')
 
 {% if rotors_dict | length > 0 -%}
 rotors = [


### PR DESCRIPTION
1. Use `form openbabel import pybel` instead of `import pybel`
2. Add `safe` filter for the directory rendering